### PR TITLE
Fix animated footer on blog and resource page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -58,7 +58,7 @@
     </section>
 
     <!-- Footer -->
-    <footer class="bg-darkgreen">
+    <footer class="bg-darkgreen" style="bottom: 0; position: fixed; width: 100%">
       <iframe src="./graphics/dynamicfooter/dynamicfooter.html" height="80px" width="100%" style="border:none;" scrolling="no"></iframe>
       <div class="bg-darkgreen">
         <div class="container">
@@ -66,7 +66,7 @@
           </div>
         </div>
       </div>
-    </footer> <!--ADDME: Style: position: fixed, bottom: 0, width: 100%-->
+    </footer>
 
   </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -66,7 +66,7 @@
           </div>
         </div>
       </div>
-    </footer>
+    </footer> <!--ADDME: Style: position: fixed, bottom: 0, width: 100%-->
 
   </body>
 </html>

--- a/css/blogstyles.css
+++ b/css/blogstyles.css
@@ -1,0 +1,5 @@
+.footer{
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+}

--- a/css/blogstyles.css
+++ b/css/blogstyles.css
@@ -1,4 +1,4 @@
-.footer{
+.defaultCanvas0{
     position: fixed;
     bottom: 0;
     width: 100%;

--- a/css/blogstyles.css
+++ b/css/blogstyles.css
@@ -1,5 +1,0 @@
-.defaultCanvas0{
-    position: fixed;
-    bottom: 0;
-    width: 100%;
-}

--- a/resources.html
+++ b/resources.html
@@ -98,7 +98,7 @@
     </section>
 
     <!-- Footer -->
-    <footer class="bg-darkgreen">
+    <footer class="bg-darkgreen" style="bottom: 0; position: fixed; width: 100%">
       <iframe src="./graphics/dynamicfooter/dynamicfooter.html" height="80px" width="100%" style="border:none;" scrolling="no"></iframe>
       <div class="bg-darkgreen">
         <div class="container">


### PR DESCRIPTION
Originally, the animated footer on the blog and resources page hovered slightly above the bottom of the page, leaving an aesthetically unpleasing white block at the bottom of the page. This fixes that.

For some reason github is showing the commits of me messing around with the css, but they are unchanged in this pull. I am unsure of how to delete commits even after scouring Google for an answer. But this should be fine.